### PR TITLE
Fix incorrect variable name

### DIFF
--- a/bsky-comments.js
+++ b/bsky-comments.js
@@ -74,7 +74,7 @@ const rootElement = document.querySelector("#comments");
             }
             else
             {
-                return uri;
+                return url;
             }
         }
 


### PR DESCRIPTION
I've tried to use this to integrate Bluesky comments onto my Hugo blog, unfortunately I was unsuccessful so went a different direction with some code I found elsewhere. However, during my attempt I found a small spelling error with a variable name that was causing this code to not work - fixed here.

Thanks! 